### PR TITLE
fix async client conetx manager

### DIFF
--- a/myscaledb/async_db/client.py
+++ b/myscaledb/async_db/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import json as json_
 import sys
 import logging
@@ -281,6 +282,14 @@ class AsyncClient(BaseClient):
             exc_tb: Optional[TracebackType],
     ) -> None:
         await self.close()
+
+    def __del__(self):
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        loop.run_until_complete(self.close())
 
     async def close(self) -> None:
         """Close the session"""

--- a/myscaledb/http_clients/abc.py
+++ b/myscaledb/http_clients/abc.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import Any, AsyncGenerator
-# import aiohttp,httpx
 from myscaledb.common.exceptions import ClientError
 
 
@@ -43,4 +42,4 @@ class HttpClientABC(ABC):
                 return HttpxHttpClient
         except ImportError:
             pass
-        raise ClientError('Async http client heeded. Please install aiohttp or httpx')
+        raise ClientError('You may not have installed aiohttp/httpx, or you may have used the wrong parameters when creating the client.')

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def read(fname):
 
 setup_opts = dict(
     name='myscaledb-client',
-    version='2.0.2',
+    version='2.0.3',
     description='Async and sync http MyScale client for python 3.6+',
     long_description=read('README.md'),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
- Add context manager to AsyncClient, avoid throwing `ERROR:asyncio:Unclosed client session`
